### PR TITLE
SBMC-5061, support multiple platdef images in the BIOS FV

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,7 @@ extern void db_smbios_handler(int argc, char *argv[]);
 extern int smbios_cfg_read_into_globalvar();
 extern void dump_apml_segments();
 
-char * version = (char*)"CHIF daemon v2.13";
+char * version = (char*)"CHIF daemon v2.14";
 
 int EVError;
 

--- a/src/uefi_util.cpp
+++ b/src/uefi_util.cpp
@@ -92,14 +92,6 @@ UEFI_RC uefi_util_platdef_store(void)
         return UEFI_RC_ERROR;
     }
 
-    // seek past the initial header.
-    if (fseek(fptr, 32, SEEK_SET)) {
-        printf("PLATDEF: Failed to seek to data in platdef file\n");
-        free(platdef_tmp);
-        fclose(fptr);
-        return UEFI_RC_ERROR;
-    }
-
     dbPrintf("Attempting to read %d bytes from platdef file\n", PLATDEF_UPDATE_BUF_SZ);
     // read in the apml data.  size was calculated in the find file routine.
     read_count = fread((UINT8 *)platdef_tmp, 1, PLATDEF_UPDATE_BUF_SZ, fptr);


### PR DESCRIPTION
Small change here to adjust to reading the platdef.dat file without a 32 byte general header.
This PR is lock-stepped with the PR in openbmc-proliant-support that now checks for more than one set of APML data or a bundle of data for multiple platforms that use the same BIOS image, such as the DL320/40 and the DL325/45 or the DL360/80.